### PR TITLE
Add filters to customize behavior for routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,25 @@ The prefix to add to every stat collected. Usually used for grouping a set of st
 
 A character or set of characters to replace the '/' (forward slash) characters in your URL path since forward slashes cannot be used in stat names. Defaults to `'_'`
 
+### `defaultFilter`
+
+Defines whether increment and timer stats are turned on by default. Defaults to `{ enableCounter: true, enableTimer: true }`.
+
+### `filters`
+
+An array of custom filters. A match is determined as follows:
+
+* Check if the filter has an `id` field and see if it matches the route's unique ID
+* Check for `path`, `method` and `status` matching the route and response
+  * Omitting `path`, `method` and `status` results in a wildcard behavior matching of anything
+
+In addition to matching, the field can contain the following configuration options:
+
+* name: Defines a custom name for the stat to be reported
+* enableTimer: Enable/disable the timer stat from being reported
+* enableCounter: Enable/disable the count stat from being reported
+
+Matches by the route's unique ID. This match takes precedence over all other types of matching
 
 ## Example
 

--- a/README.md
+++ b/README.md
@@ -99,7 +99,20 @@ In addition to matching, the field can contain the following configuration optio
 * enableTimer: Enable/disable the timer stat from being reported
 * enableCounter: Enable/disable the count stat from being reported
 
-Matches by the route's unique ID. This match takes precedence over all other types of matching
+Example configuration:
+```js
+defaultFilter: { // by default, enable timer and disable counter stats
+    enableCounter: false,
+    enableTimer: true,
+}
+filters: [
+    { path: '/', enableCounter: true }, // enable counters (keep timers on as well) for this path
+    { path: '/test/{param}', enableCounter: true }, // path with a parameter
+    { path: '/rename', name: 'rename_stat' }, // rename the metric
+    { id: 'match-my-id', enableCounter: true, enableTimer: true }, // match by route id
+    { status: 407, name: 'match_on_status', enableCounter: true, enableTimer: true }, // match by status code
+]
+````
 
 ## Example
 

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ An array of custom filters. A match is determined as follows:
 
 * Check if the filter has an `id` field and see if it matches the route's unique ID
 * Check for `path`, `method` and `status` matching the route and response
-  * Omitting `path`, `method` and `status` results in a wildcard behavior matching of anything
+  * Omitting `path`, `method` or `status` results in a wildcard behavior matching of anything
 
 In addition to matching, the field can contain the following configuration options:
 

--- a/lib/hapi-statsd.js
+++ b/lib/hapi-statsd.js
@@ -6,7 +6,12 @@ var StatsdClient = require('statsd-client'),
 		port: '8125',
 		prefix: 'hapi',
 		pathSeparator: '_',
-		template: '{path}.{method}.{statusCode}'
+		template: '{path}.{method}.{statusCode}',
+		defaultFilter: {
+			enableCounter: true,
+			enableTimer: true,
+		},
+		filters: [],
 	};
 
 module.exports.register = function (server, options, next) {
@@ -19,6 +24,28 @@ module.exports.register = function (server, options, next) {
 		normalizePath = function(path) {
 			path = (path.indexOf('/') === 0) ? path.substr(1) : path;
 			return path.replace(/\//g, settings.pathSeparator);
+		},
+		filterCache = {},
+		getFilter = function(statName, route, status) {
+			var filter = filterCache[statName];
+			if(filter) {
+				return filter;
+			}
+
+			var foundFilter = settings.filters.find(function(filter) {
+				// a match on route id
+				if (route.settings && route.settings.id && route.settings.id === filter.id) {
+					return true;
+				}
+
+				return (filter.path || filter.method || filter.status) &&
+					(!filter.path || route.path === filter.path) &&
+					(!filter.method || route.method.toUpperCase() === filter.method.toUpperCase()) &&
+					(!filter.status || status === filter.status);
+			});
+
+			filterCache[statName] = filter = Hoek.applyToDefaults(settings.defaultFilter, foundFilter || {});
+			return filter;
 		};
 
 	server.decorate('server', 'statsd', statsdClient);
@@ -26,6 +53,7 @@ module.exports.register = function (server, options, next) {
 	server.ext('onPreResponse', function (request, reply) {
 		var startDate = new Date(request.info.received);
 		var statusCode = (request.response.isBoom) ? request.response.output.statusCode : request.response.statusCode;
+		var method = request.method.toUpperCase();
 
 		var path = request._route.path;
 		var specials = request.connection._router.specials;
@@ -42,12 +70,23 @@ module.exports.register = function (server, options, next) {
 
 		var statName = settings.template
 			.replace('{path}', normalizePath(path))
-			.replace('{method}', request.method.toUpperCase())
+			.replace('{method}', method)
 			.replace('{statusCode}', statusCode);
 
 		statName = (statName.indexOf('.') === 0) ? statName.substr(1) : statName;
-		statsdClient.increment(statName);
-		statsdClient.timing(statName, startDate);
+
+		var filter = getFilter(statName, request._route, statusCode);
+		if (filter.name) {
+			statName = filter.name;
+		}
+
+		if ( filter.enableCounter ) {
+			statsdClient.increment(statName);
+		}
+
+		if ( filter.enableTimer ) {
+			statsdClient.timing(statName, startDate);
+		}
 
 		reply.continue();
 	});

--- a/lib/hapi-statsd.js
+++ b/lib/hapi-statsd.js
@@ -25,7 +25,7 @@ module.exports.register = function (server, options, next) {
 			path = (path.indexOf('/') === 0) ? path.substr(1) : path;
 			return path.replace(/\//g, settings.pathSeparator);
 		},
-		filterCache = {},
+		filterCache = {}, //cache results so that we don't have to compute them every time
 		getFilter = function(statName, route, status) {
 			var filter = filterCache[statName];
 			if(filter) {

--- a/lib/hapi-statsd.js
+++ b/lib/hapi-statsd.js
@@ -14,7 +14,7 @@ var StatsdClient = require('statsd-client'),
 		filters: [],
 	};
 
-module.exports.register = function (server, options, next) {
+module.exports.register = function(server, options, next) {
 	var settings = Hoek.applyToDefaults(defaults, options || {}),
 		statsdClient = options.statsdClient || new StatsdClient({
 			host: settings.host,
@@ -64,7 +64,7 @@ module.exports.register = function (server, options, next) {
 		else if (specials.options && request._route === specials.options.route) {
 			path = '/{cors*}';
 		}
-		else if (request._route.path === '/' && request._route.method === 'options'){
+		else if (request._route.path === '/' && request._route.method === 'options') {
 			path = '/{cors*}';
 		}
 
@@ -80,11 +80,11 @@ module.exports.register = function (server, options, next) {
 			statName = filter.name;
 		}
 
-		if ( filter.enableCounter ) {
+		if (filter.enableCounter) {
 			statsdClient.increment(statName);
 		}
 
-		if ( filter.enableTimer ) {
+		if (filter.enableTimer) {
 			statsdClient.timing(statName, startDate);
 		}
 

--- a/lib/hapi-statsd.js
+++ b/lib/hapi-statsd.js
@@ -27,9 +27,9 @@ module.exports.register = function(server, options, next) {
 		},
 		filterCache = {}, //cache results so that we don't have to compute them every time
 		getFilter = function(statName, route, status) {
-			var filter = filterCache[statName];
-			if(filter) {
-				return filter;
+			var cachedFilter = filterCache[statName];
+			if(cachedFilter) {
+				return cachedFilter;
 			}
 
 			var foundFilter = settings.filters.find(function(filter) {
@@ -38,14 +38,23 @@ module.exports.register = function(server, options, next) {
 					return true;
 				}
 
-				return (filter.path || filter.method || filter.status) &&
-					(!filter.path || route.path === filter.path) &&
-					(!filter.method || route.method.toUpperCase() === filter.method.toUpperCase()) &&
-					(!filter.status || status === filter.status);
+				if (filter.path && route.path !== filter.path) {
+					return false;
+				}
+
+				if (filter.status && status !== filter.status) {
+					return false;
+				}
+
+				if (filter.method && route.method.toUpperCase() !== filter.method.toUpperCase()) {
+					return false;
+				}
+
+				// return true if at least one of the parameters is defined
+				return filter.path || filter.method || filter.status;
 			});
 
-			filterCache[statName] = filter = Hoek.applyToDefaults(settings.defaultFilter, foundFilter || {});
-			return filter;
+			return filterCache[statName] = Hoek.applyToDefaults(settings.defaultFilter, foundFilter || {});
 		};
 
 	server.decorate('server', 'statsd', statsdClient);
@@ -53,7 +62,6 @@ module.exports.register = function(server, options, next) {
 	server.ext('onPreResponse', function (request, reply) {
 		var startDate = new Date(request.info.received);
 		var statusCode = (request.response.isBoom) ? request.response.output.statusCode : request.response.statusCode;
-		var method = request.method.toUpperCase();
 
 		var path = request._route.path;
 		var specials = request.connection._router.specials;
@@ -70,7 +78,7 @@ module.exports.register = function(server, options, next) {
 
 		var statName = settings.template
 			.replace('{path}', normalizePath(path))
-			.replace('{method}', method)
+			.replace('{method}', request.method.toUpperCase())
 			.replace('{statusCode}', statusCode);
 
 		statName = (statName.indexOf('.') === 0) ? statName.substr(1) : statName;

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
 	"contributors": [
 		"Mac Angell <mac.ang311@gmail.com>"
 	],
-	"version": "5.0.1",
+	"version": "5.1.0",
 	"dependencies": {
 		"statsd-client": "0.x.x",
 		"hoek": "3.x.x"

--- a/test/integration/hapi-statsd.tests.js
+++ b/test/integration/hapi-statsd.tests.js
@@ -36,13 +36,13 @@ beforeEach(function(done) {
 		reply(new Error());
 	};
 
-	server.route({ method: ['GET','OPTIONS'], path: '/', handler: get, config: {cors: true}});
+	server.route({ method: ['GET','OPTIONS'], path: '/', handler: get, config: {cors: true} });
 	server.route({ method: 'GET', path: '/err', handler: err, config: {cors: true} });
-	server.route({ method: 'GET', path: '/test/{param}', handler: get, config: {cors: true}});
-	server.route({ method: 'GET', path: '/default', handler: get, config: {cors: true}});
-	server.route({ method: 'GET', path: '/override', handler: get, config: {cors: true}});
-	server.route({ method: 'GET', path: '/rename', handler: get, config: {cors: true}});
-	server.route({ method: 'GET', path: '/match/id', handler: get, config: {id: 'match-my-id', cors: true}});
+	server.route({ method: 'GET', path: '/test/{param}', handler: get, config: {cors: true} });
+	server.route({ method: 'GET', path: '/default', handler: get, config: {cors: true} });
+	server.route({ method: 'GET', path: '/override', handler: get, config: {cors: true} });
+	server.route({ method: 'GET', path: '/rename', handler: get, config: {cors: true} });
+	server.route({ method: 'GET', path: '/match/id', handler: get, config: {id: 'match-my-id', cors: true} });
 
 	server.register({
 		register: plugin,
@@ -59,7 +59,7 @@ beforeEach(function(done) {
 				{ path: '/override', enableCounter: true, enableTimer: false },
 				{ path: '/rename', name: 'rename_stat', enableCounter: true, enableTimer: true },
 				{ id: 'match-my-id', name: 'match_id_stat', enableCounter: true, enableTimer: true },
-			]
+			],
 		},
 	}, done);
 });
@@ -71,7 +71,7 @@ describe('hapi-statsd plugin tests', function() {
 	});
 
 	it('should report stats with no path in stat name', function(done) {
-		server.inject('/', function (res) {
+		server.inject('/', function(res) {
 			assert(mockStatsdClient.incStat == 'GET.200');
 			assert(mockStatsdClient.timingStat == 'GET.200');
 			assert(mockStatsdClient.timingDate instanceof Date);
@@ -80,7 +80,7 @@ describe('hapi-statsd plugin tests', function() {
 	});
 
 	it('should honor default filter', function(done) {
-		server.inject('/default', function (res) {
+		server.inject('/default', function(res) {
 			assert(mockStatsdClient.incStat == '');
 			assert(mockStatsdClient.timingStat == 'default.GET.200');
 			assert(mockStatsdClient.timingDate instanceof Date);
@@ -89,7 +89,7 @@ describe('hapi-statsd plugin tests', function() {
 	});
 
 	it('should honor filter override', function(done) {
-		server.inject('/override', function (res) {
+		server.inject('/override', function(res) {
 			assert(mockStatsdClient.incStat == 'override.GET.200');
 			assert(mockStatsdClient.timingStat == '');
 			done();
@@ -97,7 +97,7 @@ describe('hapi-statsd plugin tests', function() {
 	});
 
 	it('should rename stat', function(done) {
-		server.inject('/rename', function (res) {
+		server.inject('/rename', function(res) {
 			assert(mockStatsdClient.incStat == 'rename_stat');
 			assert(mockStatsdClient.timingStat == 'rename_stat');
 			done();
@@ -105,7 +105,7 @@ describe('hapi-statsd plugin tests', function() {
 	});
 
 	it('should match on route id', function(done) {
-		server.inject('/match/id', function (res) {
+		server.inject('/match/id', function(res) {
 			assert(mockStatsdClient.incStat == 'match_id_stat');
 			assert(mockStatsdClient.timingStat == 'match_id_stat');
 			done();
@@ -113,7 +113,7 @@ describe('hapi-statsd plugin tests', function() {
 	});
 
 	it('should report stats with path in stat name', function(done) {
-		server.inject('/test/123', function (res) {
+		server.inject('/test/123', function(res) {
 			assert(mockStatsdClient.incStat == 'test_{param}.GET.200');
 			assert(mockStatsdClient.timingStat == 'test_{param}.GET.200');
 			assert(mockStatsdClient.timingDate instanceof Date);
@@ -122,7 +122,7 @@ describe('hapi-statsd plugin tests', function() {
 	});
 
 	it('should report stats with generic not found path', function(done) {
-		server.inject('/fnord', function (res) {
+		server.inject('/fnord', function(res) {
 			assert(mockStatsdClient.incStat == '');
 			assert(mockStatsdClient.timingStat == '{notFound*}.GET.404');
 			assert(mockStatsdClient.timingDate instanceof Date);
@@ -137,7 +137,7 @@ describe('hapi-statsd plugin tests', function() {
 				Origin: 'http://test.domain.com'
 			},
 			url: '/'
-		}, function (res) {
+		}, function(res) {
 			assert(mockStatsdClient.incStat == '{cors*}.OPTIONS.200');
 			assert(mockStatsdClient.timingStat == '{cors*}.OPTIONS.200');
 			assert(mockStatsdClient.timingDate instanceof Date);
@@ -146,7 +146,7 @@ describe('hapi-statsd plugin tests', function() {
 	});
 
 	it('should not change the status code of a response', function(done) {
-		server.inject('/err', function (res) {
+		server.inject('/err', function(res) {
 			assert(res.statusCode === 500);
 			done();
 		});

--- a/test/integration/hapi-statsd.tests.js
+++ b/test/integration/hapi-statsd.tests.js
@@ -96,6 +96,16 @@ describe('hapi-statsd plugin tests', function() {
 		});
 	});
 
+	it('should use cached value', function(done) {
+		server.inject('/override', function() {
+			server.inject('/override', function() {
+				assert(mockStatsdClient.incStat == 'override.GET.200');
+				assert(mockStatsdClient.timingStat == '');
+				done();
+			});
+		});
+	});
+
 	it('should rename stat', function(done) {
 		server.inject('/rename', function(res) {
 			assert(mockStatsdClient.incStat == 'rename_stat');

--- a/test/integration/hapi-statsd.tests.js
+++ b/test/integration/hapi-statsd.tests.js
@@ -18,6 +18,9 @@ var assert = require('assert'),
 	Hapi = require('hapi');
 
 beforeEach(function(done) {
+	mockStatsdClient.incStat = '';
+	mockStatsdClient.timingStat = '';
+	mockStatsdClient.timingDate = '';
 	server = new Hapi.Server();
 
 	server.connection({
@@ -36,22 +39,38 @@ beforeEach(function(done) {
 	server.route({ method: ['GET','OPTIONS'], path: '/', handler: get, config: {cors: true}});
 	server.route({ method: 'GET', path: '/err', handler: err, config: {cors: true} });
 	server.route({ method: 'GET', path: '/test/{param}', handler: get, config: {cors: true}});
+	server.route({ method: 'GET', path: '/default', handler: get, config: {cors: true}});
+	server.route({ method: 'GET', path: '/override', handler: get, config: {cors: true}});
+	server.route({ method: 'GET', path: '/rename', handler: get, config: {cors: true}});
+	server.route({ method: 'GET', path: '/match/id', handler: get, config: {id: 'match-my-id', cors: true}});
 
 	server.register({
 		register: plugin,
-		options: { statsdClient: mockStatsdClient }
+		options: {
+			statsdClient: mockStatsdClient,
+			defaultFilter: {
+				enableCounter: false,
+				enableTimer: true,
+			},
+			filters: [
+				{ path: '/', enableCounter: true },
+				{ path: '/err', enableCounter: true },
+				{ path: '/test/{param}', enableCounter: true },
+				{ path: '/override', enableCounter: true, enableTimer: false },
+				{ path: '/rename', name: 'rename_stat', enableCounter: true, enableTimer: true },
+				{ id: 'match-my-id', name: 'match_id_stat', enableCounter: true, enableTimer: true },
+			]
+		},
 	}, done);
 });
 
 describe('hapi-statsd plugin tests', function() {
 
 	it('should expose statsd client to the hapi server', function() {
-
 		assert.equal(server.statsd, mockStatsdClient);
 	});
 
 	it('should report stats with no path in stat name', function(done) {
-
 		server.inject('/', function (res) {
 			assert(mockStatsdClient.incStat == 'GET.200');
 			assert(mockStatsdClient.timingStat == 'GET.200');
@@ -60,8 +79,40 @@ describe('hapi-statsd plugin tests', function() {
 		});
 	});
 
-	it('should report stats with path in stat name', function(done) {
+	it('should honor default filter', function(done) {
+		server.inject('/default', function (res) {
+			assert(mockStatsdClient.incStat == '');
+			assert(mockStatsdClient.timingStat == 'default.GET.200');
+			assert(mockStatsdClient.timingDate instanceof Date);
+			done();
+		});
+	});
 
+	it('should honor filter override', function(done) {
+		server.inject('/override', function (res) {
+			assert(mockStatsdClient.incStat == 'override.GET.200');
+			assert(mockStatsdClient.timingStat == '');
+			done();
+		});
+	});
+
+	it('should rename stat', function(done) {
+		server.inject('/rename', function (res) {
+			assert(mockStatsdClient.incStat == 'rename_stat');
+			assert(mockStatsdClient.timingStat == 'rename_stat');
+			done();
+		});
+	});
+
+	it('should match on route id', function(done) {
+		server.inject('/match/id', function (res) {
+			assert(mockStatsdClient.incStat == 'match_id_stat');
+			assert(mockStatsdClient.timingStat == 'match_id_stat');
+			done();
+		});
+	});
+
+	it('should report stats with path in stat name', function(done) {
 		server.inject('/test/123', function (res) {
 			assert(mockStatsdClient.incStat == 'test_{param}.GET.200');
 			assert(mockStatsdClient.timingStat == 'test_{param}.GET.200');
@@ -72,7 +123,7 @@ describe('hapi-statsd plugin tests', function() {
 
 	it('should report stats with generic not found path', function(done) {
 		server.inject('/fnord', function (res) {
-			assert(mockStatsdClient.incStat == '{notFound*}.GET.404');
+			assert(mockStatsdClient.incStat == '');
 			assert(mockStatsdClient.timingStat == '{notFound*}.GET.404');
 			assert(mockStatsdClient.timingDate instanceof Date);
 			done();
@@ -95,7 +146,6 @@ describe('hapi-statsd plugin tests', function() {
 	});
 
 	it('should not change the status code of a response', function(done) {
-
 		server.inject('/err', function (res) {
 			assert(res.statusCode === 500);
 			done();


### PR DESCRIPTION
https://github.com/mac-/hapi-statsd/issues/17

This change adds filtering to the hapi-statsd plugin. For our purposes it will allow us to disable stats by default and then customize the stat names on whatever endpoint we decide to use.

Once this is reviewed and merged to master, we can test it out with our server. After that I'll request to get this merged into the original repo.

These changes should also maintain backwards compatibility with users of the plugin who are not aware or need these features.

To test:
- Review the code and unit tests
- You could in theory install this with `npm install [local path to this code]` into the `add/statsd` server branch.

@allendav @jeffstieler @DanReyLop @robobot3000 
