### PR TITLE
Update/fix route id filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,11 +87,14 @@ Defines whether increment and timer stats are turned on by default. Defaults to 
 
 ### `filters`
 
-An array of custom filters. A match is determined as follows:
-
-* Check if the filter has an `id` field and see if it matches the route's unique ID
-* Check for `path`, `method` and `status` matching the route and response
-  * Omitting `path`, `method` or `status` results in a wildcard behavior matching of anything
+An array of custom filters. A successful match requires one of these fields to be defined and match the route: 
+* `id`: The route id defined in the route's config
+* `path`: The path defined in the route
+* `method`: The HTTP method of the request/route
+* `status`: The returned HTTP status code of the response
+ 
+Parameters that are not included are considered wildcard and will match all values. Note that if none of these 
+parameters are included in the filter, then you will get a match on ALL route-response combinations.
 
 In addition to matching, the field can contain the following configuration options:
 

--- a/lib/hapi-statsd.js
+++ b/lib/hapi-statsd.js
@@ -33,7 +33,6 @@ module.exports.register = function(server, options, next) {
 			}
 
 			var foundFilter = settings.filters.find(function(filter) {
-				// a match on route id
 				if (filter.id && route.settings && route.settings.id !== filter.id) {
 					return false;
 				}
@@ -50,8 +49,8 @@ module.exports.register = function(server, options, next) {
 					return false;
 				}
 
-				// return true if at least one of the parameters is defined
-				return filter.id || filter.path || filter.method || filter.status;
+				// If none of the above checks failed, then we have a match
+				return true;
 			});
 
 			return filterCache[statName] = Hoek.applyToDefaults(settings.defaultFilter, foundFilter || {});

--- a/lib/hapi-statsd.js
+++ b/lib/hapi-statsd.js
@@ -34,8 +34,8 @@ module.exports.register = function(server, options, next) {
 
 			var foundFilter = settings.filters.find(function(filter) {
 				// a match on route id
-				if (route.settings && route.settings.id && route.settings.id === filter.id) {
-					return true;
+				if (filter.id && route.settings && route.settings.id !== filter.id) {
+					return false;
 				}
 
 				if (filter.path && route.path !== filter.path) {
@@ -51,7 +51,7 @@ module.exports.register = function(server, options, next) {
 				}
 
 				// return true if at least one of the parameters is defined
-				return filter.path || filter.method || filter.status;
+				return filter.id || filter.path || filter.method || filter.status;
 			});
 
 			return filterCache[statName] = Hoek.applyToDefaults(settings.defaultFilter, foundFilter || {});


### PR DESCRIPTION
This makes the behavior of the id filter more consistent with how all the other parameters work. It also allows for a wildcard "match all" filter.
